### PR TITLE
fix(pr template): remove broken link

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,3 @@
-<!-- Thanks for your pull-request!
-
-Please, make sure you've read `CONTRIBUTING.md` before submitting this PR.
-
--->
-
 #### Description
 
 <!-- Describe your pull-request, what was changed and why… -->


### PR DESCRIPTION
The PR template has a link to CONTRIBUTING.md, but that file doesn't exist. 